### PR TITLE
Emulate spotify connect and stream to discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,3 @@
-DISCORD_TOKEN=
-CLIENT_ID=
-SPOTIFY_CLIENT_ID=
-SPOTIFY_CLIENT_SECRET=
-
 # Optional: librespot configuration
 LIBRESPOT_DEVICE_NAME=Discord Connect
 # FIFO path for pipe backend. Defaults to OS temp dir if not set.
@@ -20,6 +15,7 @@ LIBRESPOT_ZEROCONF_PORT=
 FFMPEG_PATH=
 FFMPEG_LOGLEVEL=warning
 DISCORD_OPUS_BITRATE=160k
+
 # Discord Bot Configuration
 DISCORD_TOKEN=your_discord_bot_token_here
 CLIENT_ID=your_discord_application_client_id_here

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,25 @@
+DISCORD_TOKEN=
+CLIENT_ID=
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Optional: librespot configuration
+LIBRESPOT_DEVICE_NAME=Discord Connect
+# FIFO path for pipe backend. Defaults to OS temp dir if not set.
+LIBRESPOT_FIFO_PATH=/tmp/librespot-discord.fifo
+# Path to librespot binary if not in PATH
+LIBRESPOT_PATH=
+# Bitrate: 96, 160, 320
+LIBRESPOT_BITRATE=160
+# Device type: speaker, computer, smartphone, etc.
+LIBRESPOT_DEVICE_TYPE=speaker
+# Optional fixed zeroconf port
+LIBRESPOT_ZEROCONF_PORT=
+
+# Optional: ffmpeg and opus encode settings
+FFMPEG_PATH=
+FFMPEG_LOGLEVEL=warning
+DISCORD_OPUS_BITRATE=160k
 # Discord Bot Configuration
 DISCORD_TOKEN=your_discord_bot_token_here
 CLIENT_ID=your_discord_application_client_id_here

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ sudo install -Dm755 ./librespot /usr/local/bin/librespot
 ```
 Or set `LIBRESPOT_PATH` in `.env` to point to your binary.
 
+6. Install avahi (required). On Linux, you can download a release binary. This is necessary for managing the librespot zero-conf networking
+
 ### 4. Running the Bot
 
 Start the bot:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ sudo install -Dm755 ./librespot /usr/local/bin/librespot
 ```
 Or set `LIBRESPOT_PATH` in `.env` to point to your binary.
 
+If audio sounds pitched or sped up, ensure resampling is correct. This bot treats librespot's pipe output as 44.1kHz and resamples to 48kHz for Discord. If you changed librespot's output rate, set `LIBRESPOT_SAMPLE_RATE` accordingly.
+
 6. Install avahi (required). On Linux, you can download a release binary. This is necessary for managing the librespot zero-conf networking
 
 ### 4. Running the Bot

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Discord Spotify Bot
+# Discord Spotify Connect to Discord Bot
 
-A Discord bot that allows users to search and query music from Spotify using slash commands. Share music with friends in Discord!
+A Discord bot that emulates a Spotify Connect device (via librespot) and streams that audio into a Discord voice channel. Includes `/device start` to expose a Connect device, and `/join`/`/leave` to manage voice. Also supports `/play` to search Spotify metadata.
 
 ## Features
 
-- Search songs by name, artist, or album
-- Get track information from Spotify URLs
-- Fast slash command interface using `/play`
-- Display detailed track information including duration, popularity, and preview links
-- Automatic Spotify API token management
+- **Spotify Connect device**: Uses librespot with pipe backend to output raw PCM
+- **Audio pipeline to Discord**: ffmpeg encodes PCM to Ogg/Opus for Discord voice
+- **Slash commands**: `/join`, `/leave`, `/device start|stop|status`, `/play`
+- **Spotify search**: Metadata search and track info via Spotify Web API
+- **Token management**: Automatic Spotify Client Credentials token refresh
 
 ## Commands
 
@@ -68,6 +68,12 @@ SPOTIFY_CLIENT_ID=your_spotify_client_id_here
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
 ```
 
+5. Install librespot (required). On Linux, you can download a release binary:
+```bash
+sudo install -Dm755 ./librespot /usr/local/bin/librespot
+```
+Or set `LIBRESPOT_PATH` in `.env` to point to your binary.
+
 ### 4. Running the Bot
 
 Start the bot:
@@ -80,7 +86,13 @@ For development with auto-restart:
 npm run dev
 ```
 
-## Usage Examples
+## Usage
+
+1. In a Discord server, run:
+   - `/join` to have the bot join your voice channel
+   - `/device start` to start the Spotify Connect device
+2. Open Spotify on your phone/desktop, select device "Discord Connect" (or your `LIBRESPOT_DEVICE_NAME`) and press Play.
+3. Use `/device status` to check state, `/device stop` to stop, `/leave` to disconnect.
 
 ### Search by song name:
 ```
@@ -101,7 +113,10 @@ npm run dev
 
 ```
 discord-spotify-bot/
-├── index.js           # Main bot file with Discord and Spotify integration
+├── index.js           # Main bot file and command wiring
+├── lib/
+│  ├── librespot.js    # Wrapper to run librespot with pipe backend -> FIFO
+│  └── voice.js        # Voice connect and ffmpeg encode to Discord
 ├── package.json       # Node.js dependencies and scripts
 ├── .env.example       # Environment variables template
 ├── .gitignore        # Git ignore file

--- a/commands/device.js
+++ b/commands/device.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const { SlashCommandBuilder } = require("discord.js");
+
+function initializeDeviceCommand() {
+    return {
+        data: new SlashCommandBuilder()
+            .setName('device')
+            .setDescription('Manage the Spotify Connect device')
+            .addSubcommand(sub => sub
+                .setName('start')
+                .setDescription('Start the Spotify Connect device (librespot)'))
+            .addSubcommand(sub => sub
+                .setName('stop')
+                .setDescription('Stop the Spotify Connect device'))
+            .addSubcommand(sub => sub
+                .setName('status')
+                .setDescription('Show device status')),
+        async execute(interaction) {
+            await interaction.deferReply({ ephemeral: true });
+            const sub = interaction.options.getSubcommand();
+            try {
+                if (sub === 'start') {
+                    if (!this.voice.connection) {
+                        await this.voice.joinVoiceChannelByInteraction(interaction);
+                    }
+                    this.librespot.start();
+                    this.voice.playFromFifo(this.librespot.fifoPath);
+                    await interaction.editReply(`Device started as "${this.librespot.deviceName}". Select it in Spotify and press play.`);
+                } else if (sub === 'stop') {
+                    this.voice.stopPlayback();
+                    this.librespot.stop();
+                    await interaction.editReply('Device stopped.');
+                } else if (sub === 'status') {
+                    const status = this.librespot.isRunning() ? 'running' : 'stopped';
+                    const vc = this.voice.connection ? 'connected' : 'disconnected';
+                    await interaction.editReply(`Device is ${status}. Voice is ${vc}. FIFO: ${this.librespot.fifoPath}`);
+                }
+            } catch (err) {
+                await interaction.editReply(`Error: ${err.message}`);
+            }
+        }
+    };
+}
+
+module.exports = { initializeDeviceCommand };
+

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,1 +1,6 @@
-export { initializePlayCommand } from './play.js';
+module.exports = {
+    ...require('./play.js'),
+    ...require('./join.js'),
+    ...require('./leave.js'),
+    ...require('./device.js')
+};

--- a/commands/join.js
+++ b/commands/join.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { SlashCommandBuilder } = require("discord.js");
+
+function initializeJoinCommand() {
+    return {
+        data: new SlashCommandBuilder()
+            .setName('join')
+            .setDescription('Join your current voice channel'),
+        async execute(interaction) {
+            await interaction.deferReply({ ephemeral: true });
+            try {
+                await this.voice.joinVoiceChannelByInteraction(interaction);
+                await interaction.editReply('Joined your voice channel.');
+            } catch (err) {
+                await interaction.editReply(`Failed to join: ${err.message}`);
+            }
+        }
+    };
+}
+
+module.exports = { initializeJoinCommand };
+

--- a/commands/leave.js
+++ b/commands/leave.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { SlashCommandBuilder } = require("discord.js");
+
+function initializeLeaveCommand() {
+    return {
+        data: new SlashCommandBuilder()
+            .setName('leave')
+            .setDescription('Leave the voice channel and stop playback'),
+        async execute(interaction) {
+            await interaction.deferReply({ ephemeral: true });
+            try {
+                this.voice.leave();
+                await interaction.editReply('Left the voice channel.');
+            } catch (err) {
+                await interaction.editReply(`Failed to leave: ${err.message}`);
+            }
+        }
+    };
+}
+
+module.exports = { initializeLeaveCommand };
+

--- a/commands/play.js
+++ b/commands/play.js
@@ -1,6 +1,6 @@
-import { SlashCommandBuilder } from "discord.js";
+const { SlashCommandBuilder } = require("discord.js");
 
-export function initializePlayCommand() {
+function initializePlayCommand() {
 	return {
 		data: new SlashCommandBuilder()
 			 .setName('play')
@@ -30,5 +30,7 @@ export function initializePlayCommand() {
 				  await interaction.editReply('Sorry, there was an error processing your request. Please try again.');
 			 }
 		}
-	}
+	};
 }
+
+module.exports = { initializePlayCommand };

--- a/lib/librespot.js
+++ b/lib/librespot.js
@@ -1,0 +1,105 @@
+"use strict";
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const which = require("which");
+
+class LibrespotController {
+    constructor(options = {}) {
+        this.deviceName = options.deviceName || process.env.LIBRESPOT_DEVICE_NAME || "Discord Connect";
+        this.fifoPath = options.fifoPath || process.env.LIBRESPOT_FIFO_PATH || path.join(os.tmpdir(), "librespot-discord.fifo");
+        this.librespotPath = options.librespotPath || process.env.LIBRESPOT_PATH || null;
+        this.sampleRate = 48000; // Discord expects 48kHz
+        this.format = "S16"; // Signed 16-bit PCM
+        this.process = null;
+    }
+
+    ensureFifo() {
+        if (fs.existsSync(this.fifoPath)) {
+            const stat = fs.statSync(this.fifoPath);
+            // If it's a regular file, remove and recreate as FIFO
+            if (!stat.isFIFO && typeof stat.isFIFO !== "function") {
+                // Node's fs.Stats may not have isFIFO on some platforms; fall back to recreate
+                fs.rmSync(this.fifoPath, { force: true });
+            } else if (typeof stat.isFIFO === "function" && !stat.isFIFO()) {
+                fs.rmSync(this.fifoPath, { force: true });
+            }
+        }
+
+        if (!fs.existsSync(this.fifoPath)) {
+            // mkfifo is available on Linux; create with world rw so ffmpeg/node can read
+            spawn("mkfifo", ["-m", "666", this.fifoPath]);
+        }
+    }
+
+    resolveLibrespotPath() {
+        if (this.librespotPath && fs.existsSync(this.librespotPath)) {
+            return this.librespotPath;
+        }
+        try {
+            const resolved = which.sync("librespot");
+            return resolved;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    isRunning() {
+        return !!this.process;
+    }
+
+    start() {
+        if (this.process) return;
+
+        const binary = this.resolveLibrespotPath();
+        if (!binary) {
+            throw new Error("librespot binary not found. Install librespot and/or set LIBRESPOT_PATH env.");
+        }
+
+        this.ensureFifo();
+
+        const args = [
+            "--name", this.deviceName,
+            "--backend", "pipe",
+            "--device", this.fifoPath,
+            "--format", this.format,
+            "--sample-rate", String(this.sampleRate),
+            "--bitrate", process.env.LIBRESPOT_BITRATE || "160",
+            "--disable-audio-cache",
+            "--device-type", process.env.LIBRESPOT_DEVICE_TYPE || "speaker",
+            // Zeroconf enabled by default; bind to random port if provided
+            ...(process.env.LIBRESPOT_ZEROCONF_PORT ? ["--zeroconf-port", process.env.LIBRESPOT_ZEROCONF_PORT] : [])
+        ];
+
+        this.process = spawn(binary, args, { stdio: ["ignore", "pipe", "pipe"] });
+
+        this.process.stdout.on("data", (data) => {
+            // librespot logs to stdout
+            process.stdout.write(`[librespot] ${data}`);
+        });
+        this.process.stderr.on("data", (data) => {
+            process.stderr.write(`[librespot] ${data}`);
+        });
+        this.process.on("exit", (code, signal) => {
+            this.process = null;
+            console.log(`librespot exited with code ${code} signal ${signal}`);
+        });
+        this.process.on("error", (err) => {
+            console.error("Failed to start librespot:", err);
+            this.process = null;
+        });
+    }
+
+    stop() {
+        if (!this.process) return;
+        try {
+            this.process.kill("SIGTERM");
+        } catch (_) {}
+        this.process = null;
+    }
+}
+
+module.exports = { LibrespotController };
+

--- a/lib/librespot.js
+++ b/lib/librespot.js
@@ -11,7 +11,6 @@ class LibrespotController {
         this.deviceName = options.deviceName || process.env.LIBRESPOT_DEVICE_NAME || "Discord Connect";
         this.fifoPath = options.fifoPath || process.env.LIBRESPOT_FIFO_PATH || path.join(os.tmpdir(), "librespot-discord.fifo");
         this.librespotPath = options.librespotPath || process.env.LIBRESPOT_PATH || null;
-        this.sampleRate = 48000; // Discord expects 48kHz
         this.format = "S16"; // Signed 16-bit PCM
         this.process = null;
     }
@@ -65,7 +64,6 @@ class LibrespotController {
             "--backend", "pipe",
             "--device", this.fifoPath,
             "--format", this.format,
-            "--sample-rate", String(this.sampleRate),
             "--bitrate", process.env.LIBRESPOT_BITRATE || "160",
             "--disable-audio-cache",
             "--device-type", process.env.LIBRESPOT_DEVICE_TYPE || "speaker",

--- a/lib/voice.js
+++ b/lib/voice.js
@@ -89,13 +89,17 @@ class VoiceController {
             this.currentFfmpeg = null;
         }
 
-        // Read raw PCM S16LE 48k stereo from the fifo and encode to Ogg/Opus for Discord
+        // Read raw PCM S16LE 44.1k stereo from the fifo (librespot default),
+        // resample to 48k for Discord, and encode to Ogg/Opus
         const ffmpegArgs = [
             "-hide_banner", "-loglevel", process.env.FFMPEG_LOGLEVEL || "warning",
             "-f", "s16le",
-            "-ar", "48000",
+            "-ar", process.env.LIBRESPOT_SAMPLE_RATE || "44100",
             "-ac", "2",
             "-i", fifoPath,
+            // Output settings
+            "-ar", "48000",
+            "-ac", "2",
             "-vn",
             "-acodec", "libopus",
             "-b:a", process.env.DISCORD_OPUS_BITRATE || "160k",

--- a/lib/voice.js
+++ b/lib/voice.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const { joinVoiceChannel, createAudioPlayer, NoSubscriberBehavior, createAudioResource, AudioPlayerStatus, StreamType, entersState, VoiceConnectionStatus } = require("@discordjs/voice");
+const { Readable } = require("stream");
+const { spawn } = require("child_process");
+const fs = require("fs");
+const which = require("which");
+const path = require("path");
+
+class VoiceController {
+    constructor(options = {}) {
+        this.connection = null;
+        this.audioPlayer = createAudioPlayer({
+            behaviors: {
+                noSubscriber: NoSubscriberBehavior.Play
+            }
+        });
+        this.ffmpegPath = options.ffmpegPath || process.env.FFMPEG_PATH || null;
+        this.currentFfmpeg = null;
+        this.onDebugLog = options.onDebugLog || (() => {});
+    }
+
+    resolveFfmpegPath() {
+        if (this.ffmpegPath && fs.existsSync(this.ffmpegPath)) return this.ffmpegPath;
+        try {
+            // Prefer static binary if available
+            const staticPath = require("ffmpeg-static");
+            if (staticPath && fs.existsSync(staticPath)) return staticPath;
+        } catch (_) {}
+        try {
+            return which.sync("ffmpeg");
+        } catch (err) {
+            return null;
+        }
+    }
+
+    async joinVoiceChannelByInteraction(interaction) {
+        const channel = interaction.member?.voice?.channel;
+        if (!channel) {
+            throw new Error("You must be in a voice channel to use this command.");
+        }
+        return this.join(channel.guild.id, channel.id, channel.guild.voiceAdapterCreator);
+    }
+
+    async join(guildId, channelId, adapterCreator) {
+        this.connection = joinVoiceChannel({
+            channelId,
+            guildId,
+            adapterCreator,
+            selfDeaf: false,
+            selfMute: false
+        });
+
+        this.connection.on("stateChange", (oldState, newState) => {
+            this.onDebugLog(`Voice connection state ${oldState.status} -> ${newState.status}`);
+        });
+
+        this.connection.subscribe(this.audioPlayer);
+        try {
+            await entersState(this.connection, VoiceConnectionStatus.Ready, 15_000);
+        } catch (err) {
+            this.connection.destroy();
+            this.connection = null;
+            throw err;
+        }
+        return this.connection;
+    }
+
+    leave() {
+        if (this.connection) {
+            try { this.connection.destroy(); } catch (_) {}
+            this.connection = null;
+        }
+        this.stopPlayback();
+    }
+
+    playFromFifo(fifoPath) {
+        if (!this.connection) {
+            throw new Error("Not connected to a voice channel.");
+        }
+
+        const ffmpegBinary = this.resolveFfmpegPath();
+        if (!ffmpegBinary) {
+            throw new Error("ffmpeg not found. Install ffmpeg or add ffmpeg-static dependency.");
+        }
+
+        if (this.currentFfmpeg) {
+            try { this.currentFfmpeg.kill("SIGTERM"); } catch (_) {}
+            this.currentFfmpeg = null;
+        }
+
+        // Read raw PCM S16LE 48k stereo from the fifo and encode to Ogg/Opus for Discord
+        const ffmpegArgs = [
+            "-hide_banner", "-loglevel", process.env.FFMPEG_LOGLEVEL || "warning",
+            "-f", "s16le",
+            "-ar", "48000",
+            "-ac", "2",
+            "-i", fifoPath,
+            "-vn",
+            "-acodec", "libopus",
+            "-b:a", process.env.DISCORD_OPUS_BITRATE || "160k",
+            "-f", "ogg",
+            "pipe:1"
+        ];
+
+        const ffmpeg = spawn(ffmpegBinary, ffmpegArgs, { stdio: ["ignore", "pipe", "pipe"] });
+        this.currentFfmpeg = ffmpeg;
+
+        ffmpeg.stderr.on("data", (d) => this.onDebugLog(`[ffmpeg] ${d}`));
+        ffmpeg.on("exit", (code, signal) => {
+            this.onDebugLog(`ffmpeg exited with code ${code}, signal ${signal}`);
+            if (this.currentFfmpeg === ffmpeg) {
+                this.currentFfmpeg = null;
+            }
+        });
+
+        const resource = createAudioResource(ffmpeg.stdout, {
+            inputType: StreamType.OggOpus,
+            inlineVolume: false
+        });
+
+        this.audioPlayer.on("error", (error) => {
+            this.onDebugLog(`Audio player error: ${error.message}`);
+        });
+
+        this.audioPlayer.on(AudioPlayerStatus.Idle, () => {
+            // Keep-alive; if ffmpeg stops, we end up idle
+        });
+
+        this.audioPlayer.play(resource);
+        return resource;
+    }
+
+    stopPlayback() {
+        if (this.audioPlayer) {
+            try { this.audioPlayer.stop(true); } catch (_) {}
+        }
+        if (this.currentFfmpeg) {
+            try { this.currentFfmpeg.kill("SIGTERM"); } catch (_) {}
+            this.currentFfmpeg = null;
+        }
+    }
+}
+
+module.exports = { VoiceController };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/voice": "^0.19.0",
+        "@snazzah/davey": "^0.1.6",
         "discord.js": "^14.22.1",
         "dotenv": "^17.2.2",
         "ffmpeg-static": "^5.2.0",
@@ -179,6 +180,49 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
@@ -210,6 +254,268 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@snazzah/davey": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey/-/davey-0.1.6.tgz",
+      "integrity": "sha512-wKJDQ7iobl3rvuQDXLC2yZdpuVxPvMnbyjyPpkcETqPfqNVrdyX9zSdV74dnkpx7aLpINEmKh8ZEIlCIJA2h1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Snazzah"
+      },
+      "optionalDependencies": {
+        "@snazzah/davey-android-arm-eabi": "0.1.6",
+        "@snazzah/davey-android-arm64": "0.1.6",
+        "@snazzah/davey-darwin-arm64": "0.1.6",
+        "@snazzah/davey-darwin-x64": "0.1.6",
+        "@snazzah/davey-freebsd-x64": "0.1.6",
+        "@snazzah/davey-linux-arm-gnueabihf": "0.1.6",
+        "@snazzah/davey-linux-arm64-gnu": "0.1.6",
+        "@snazzah/davey-linux-arm64-musl": "0.1.6",
+        "@snazzah/davey-linux-x64-gnu": "0.1.6",
+        "@snazzah/davey-linux-x64-musl": "0.1.6",
+        "@snazzah/davey-wasm32-wasi": "0.1.6",
+        "@snazzah/davey-win32-arm64-msvc": "0.1.6",
+        "@snazzah/davey-win32-ia32-msvc": "0.1.6",
+        "@snazzah/davey-win32-x64-msvc": "0.1.6"
+      }
+    },
+    "node_modules/@snazzah/davey-android-arm-eabi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm-eabi/-/davey-android-arm-eabi-0.1.6.tgz",
+      "integrity": "sha512-6Fso+kxvvIcmUdTgU4etHjvEZUwGwvIk+SUYxKTRZKz/S62pZvcFeZfbofpQC5ZIlt/rdp7l+4IM62J7PUduxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-android-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm64/-/davey-android-arm64-0.1.6.tgz",
+      "integrity": "sha512-5ZGLumjewJAmGAcHqSHb2+KZSSufdNY++/GouzqdQXfhs2bSNBPuHpNn94u6//5UK0o73udJ6B1H/uLOLfEBLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-arm64/-/davey-darwin-arm64-0.1.6.tgz",
+      "integrity": "sha512-0k6gOm29bcznz4ND1gfJVKeCxfyFw/EtfhPQvQ2PPJToSIaSvVqfYIlj/v9ogWW/lzuPI4EbLP0b6hnZkKidbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-x64/-/davey-darwin-x64-0.1.6.tgz",
+      "integrity": "sha512-y9UuymB5JTi9LSwjsCZDf/mjI6nAum1+uYX2h4xdO+VUxXQSAR4B2mr3lCI7l9KwYqW7JVDN5wETithAkXcTYA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-freebsd-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-freebsd-x64/-/davey-freebsd-x64-0.1.6.tgz",
+      "integrity": "sha512-G0XzHi+pZqTZ5Zr7Z66J6oGOG07+Obw7f0CwD9nAJcSFlKnd8wYzTjL+krHfQxmLHnuA5w/9df+M9oDJDcGcJw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm-gnueabihf": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm-gnueabihf/-/davey-linux-arm-gnueabihf-0.1.6.tgz",
+      "integrity": "sha512-RaxTzO8iJfDvj4a8OcXRwcP+2WfaCcno28ZWFMTI0pHEviG3MfLH5COAIvtMQvg0XfC+HgFC4YA1d29S8Dhvbg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-gnu": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-gnu/-/davey-linux-arm64-gnu-0.1.6.tgz",
+      "integrity": "sha512-2BIJSWs4rHq4U9A7B6WtF1LzwYJrbFUz5SQVmwqwQXKJ8cm81iizqclDGWr3zFGiVPTXLZ/+G3wnQNDB54oABQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-musl": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-musl/-/davey-linux-arm64-musl-0.1.6.tgz",
+      "integrity": "sha512-N1egO+HT8cvSdIGCzJNRVH3ZhxCIYKVYxEkfzVZaBx26snN8NF737YTVRldl84w//3tdgohyl27yrn+dMkWS2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-gnu": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-gnu/-/davey-linux-x64-gnu-0.1.6.tgz",
+      "integrity": "sha512-RAC96Y//HHoMP+1MUf4rOkBq5Nx6GCiOGeGsNXt7r02lbIthoFEPYFQdbfc9jYA79k67gpzmCa0N5ws7ZLVU5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-musl": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-musl/-/davey-linux-x64-musl-0.1.6.tgz",
+      "integrity": "sha512-nBvxJTKlQFP9UsQ7ah78L+rGdcwLWKDR8z/knut/M+UZLe37vaponJAbY3F5ZqGAcfqJbwUi/CXR77t9E+TDmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-wasm32-wasi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-wasm32-wasi/-/davey-wasm32-wasi-0.1.6.tgz",
+      "integrity": "sha512-hvpZH6a4mYZiXv6vdZaFwjPProgFtb3k4BoMvEEJZDXsEPuIDgp+d2BX5Q9nVazdnJa/6JR/XCuObzugPWp0Ew==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-arm64-msvc": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-arm64-msvc/-/davey-win32-arm64-msvc-0.1.6.tgz",
+      "integrity": "sha512-iuxYXXa0Z8eAEZotAlMYUc5DCy3VonRXQMm8/w2EvM/ZzGBI7SMap0GhPf6HjArEW32ETarTLh1s/Yi/jhFPDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-ia32-msvc": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-ia32-msvc/-/davey-win32-ia32-msvc-0.1.6.tgz",
+      "integrity": "sha512-QEubcCIBR+ZZoQzRzJuOuKcH2IaF2pFXU+t48ITHG1o2WL4NAnvc3IpfVQGhbkr+DlydZ6fKNMMEemd1pRZzRA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-x64-msvc": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-x64-msvc/-/davey-win32-x64-msvc-0.1.6.tgz",
+      "integrity": "sha512-8tR3o+amQOHJL8QzSwuSCCave+jm3SC1m1OKSh9Coy4wN/XoJN0XQUxqzA7ineSClAMW3yIO0ShFmMlMIXsC0A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,28 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@discordjs/voice": "^0.19.0",
         "discord.js": "^14.22.1",
         "dotenv": "^17.2.2",
-        "spotify-web-api-node": "^5.0.2"
+        "ffmpeg-static": "^5.2.0",
+        "prism-media": "^1.3.5",
+        "spotify-web-api-node": "^5.0.2",
+        "which": "^5.0.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -101,6 +120,25 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
+      "integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.16",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.8.1",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
@@ -202,10 +240,28 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
@@ -237,6 +293,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -256,6 +318,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/cookiejar": {
@@ -352,6 +429,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -408,6 +494,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/form-data": {
       "version": "3.0.4",
@@ -532,11 +634,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -623,6 +762,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/qs": {
@@ -811,6 +990,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "6.21.3",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
@@ -831,6 +1016,21 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,35 @@
 {
   "name": "discord-spotify-bot",
   "version": "1.0.0",
-  "description": "A Discord bot for querying and playing music from Spotify",
+  "description": "A Discord bot that emulates a Spotify Connect device and streams to Discord",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "node index.js",
-    "test": "node test.js"
+    "dev": "node index.js"
   },
-  "keywords": ["discord", "spotify", "bot", "music"],
+  "keywords": [
+    "discord",
+    "spotify",
+    "bot",
+    "music"
+  ],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@discordjs/voice": "^0.19.0",
     "discord.js": "^14.22.1",
     "dotenv": "^17.2.2",
-    "spotify-web-api-node": "^5.0.2"
-  }
+    "ffmpeg-static": "^5.2.0",
+    "prism-media": "^1.3.5",
+    "spotify-web-api-node": "^5.0.2",
+    "which": "^5.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SullivanXiong/discord-spotify-bot.git"
+  },
+  "bugs": {
+    "url": "https://github.com/SullivanXiong/discord-spotify-bot/issues"
+  },
+  "homepage": "https://github.com/SullivanXiong/discord-spotify-bot#readme"
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@discordjs/voice": "^0.19.0",
+    "@snazzah/davey": "^0.1.6",
     "discord.js": "^14.22.1",
     "dotenv": "^17.2.2",
     "ffmpeg-static": "^5.2.0",


### PR DESCRIPTION
Add Spotify Connect device emulation via librespot and stream its audio to Discord.

This implements Spoticord-like functionality, allowing users to select a "Discord Connect" device in Spotify and have its audio streamed directly into a Discord voice channel.

---
<a href="https://cursor.com/background-agent?bcId=bc-32606895-87ad-4d56-92ba-79fef78a7a1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32606895-87ad-4d56-92ba-79fef78a7a1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

